### PR TITLE
fix(deps): lock the DA into terraform version 1.10.5

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -298,7 +298,8 @@
                 "description": "The Standard variation of the Web App Multi-Zone Resiliency deployable architecture."
               }
             ]
-          }
+          },
+          "terraform_version": "1.10.5"
         }
       ]
     }


### PR DESCRIPTION

        This PR ensures that the `ibm_catalog.json` file includes the required `terraform_version` field.

        An upcoming version of **`common-dev-assets`** will introduce an updated `pre-commit` hook that enforces this check. Applying this change now ensures compatibility with the new hook and avoids future commit failures.
        